### PR TITLE
Add support for PLAIN SASL authentication

### DIFF
--- a/src/Gremlin.Net/ConnectionPool.cs
+++ b/src/Gremlin.Net/ConnectionPool.cs
@@ -29,14 +29,18 @@ namespace Gremlin.Net
         private readonly ConcurrentBag<Connection> _connections = new ConcurrentBag<Connection>();
         private readonly object _connectionsLock = new object();
         private readonly Uri _uri;
+        private readonly string _username;
+        private readonly string _password;
 
-        public ConnectionPool(Uri uri)
+        public ConnectionPool(Uri uri, string username, string password)
         {
             _uri = uri;
+            _username = username;
+            _password = password;
         }
 
         public int NrConnections { get; private set; }
-        
+
         public async Task<IConnection> GetAvailableConnectionAsync()
         {
             Connection connection = null;
@@ -56,7 +60,7 @@ namespace Gremlin.Net
         {
             NrConnections++;
             var newConnection = new Connection();
-            await newConnection.ConnectAsync(_uri).ConfigureAwait(false);
+            await newConnection.ConnectAsync(_uri, _username, _password).ConfigureAwait(false);
             return newConnection;
         }
 

--- a/src/Gremlin.Net/GremlinClient.cs
+++ b/src/Gremlin.Net/GremlinClient.cs
@@ -36,7 +36,7 @@ namespace Gremlin.Net
         /// <param name="gremlinServer">The <see cref="GremlinServer"/> the requests should be sent to.</param>
         public GremlinClient(GremlinServer gremlinServer)
         {
-            _connectionPool = new ConnectionPool(gremlinServer.Uri);
+            _connectionPool = new ConnectionPool(gremlinServer.Uri, gremlinServer.Username, gremlinServer.Password);
         }
 
         /// <summary>

--- a/src/Gremlin.Net/GremlinServer.cs
+++ b/src/Gremlin.Net/GremlinServer.cs
@@ -31,9 +31,13 @@ namespace Gremlin.Net
         /// <param name="hostname">The hostname of the server.</param>
         /// <param name="port">The port on which Gremlin Server can be reached.</param>
         /// <param name="enableSsl">Specifies whether SSL should be enabled.</param>
-        public GremlinServer(string hostname, int port = 8182, bool enableSsl = false)
+        /// <param name="Username">The username to connect the Gremlin Server.</param>
+        /// <param name="Password">The password to connect the Gremlin Server.</param>
+        public GremlinServer(string hostname, int port = 8182, bool enableSsl = false, string Username = null, string Password = null)
         {
             Uri = CreateUri(hostname, port, enableSsl);
+            this.Username = Username;
+            this.Password = Password;
         }
 
         /// <summary>
@@ -41,6 +45,18 @@ namespace Gremlin.Net
         /// </summary>
         /// <value>The WebSocket <see cref="System.Uri"/> that the Gremlin Server responds to.</value>
         public Uri Uri { get; }
+
+        /// <summary>
+        /// Gets the username to connect the Gremlin Server.
+        /// </summary>
+        /// <value>The username to connect the Gremlin Server.</value>
+        public string Username { get; }
+
+        /// <summary>
+        /// Gets the password to connect the Gremlin Server.
+        /// </summary>
+        /// <value>The password to connect the Gremlin Server.</value>
+        public string Password { get; }
 
         private Uri CreateUri(string hostname, int port, bool enableSsl)
         {

--- a/src/Gremlin.Net/JsonMessageSerializer.cs
+++ b/src/Gremlin.Net/JsonMessageSerializer.cs
@@ -26,10 +26,10 @@ namespace Gremlin.Net
     {
         private const string MimeType = "application/json";
 
-        public byte[] SerializeMessage(ScriptRequestMessage message)
+        public byte[] SerializeMessage(RequestMessage message)
         {
             var payload = JsonConvert.SerializeObject(message);
-            var messageWithHeader = $"{(char) MimeType.Length}{MimeType}{payload}";
+            var messageWithHeader = $"{(char)MimeType.Length}{MimeType}{payload}";
             return Encoding.UTF8.GetBytes(messageWithHeader);
         }
 

--- a/src/Gremlin.Net/Messages/AuthenticationRequestArguments.cs
+++ b/src/Gremlin.Net/Messages/AuthenticationRequestArguments.cs
@@ -16,28 +16,30 @@
  */
 #endregion
 
-using System;
 using Newtonsoft.Json;
 
 namespace Gremlin.Net.Messages
 {
     /// <summary>
-    /// Represents a script request message to send to a Gremlin Server.
+    /// Represents parameters to pass to Gremlin Server for a <see cref="AuthenticationRequestMessage"/>.
     /// </summary>
-    public class ScriptRequestMessage : RequestMessage
+    public class AuthenticationRequestArguments : RequestArguments
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ScriptRequestMessage"/> class.
+        /// Initializes a new instance of the <see cref="AuthenticationRequestArguments"/> class.
         /// </summary>
-        public ScriptRequestMessage()
+        /// <param name="username">The username.</param>
+        /// <param name="password">The password.</param>
+        public AuthenticationRequestArguments(string username, string password)
         {
-            this.Operation = "eval";
+            this.Sasl = $"\0{username}\0{password}";
         }
 
         /// <summary>
-        /// Gets or sets parameters for this <see cref="ScriptRequestMessage"/> to pass to Gremlin Server.
+        /// Gets or sets the response to the server authentication challenge. This value is dependent on the SASL authentication mechanism required by the server.
         /// </summary>
-        [JsonProperty(PropertyName = "args")]
-        public ScriptRequestArguments Arguments { get; set; }
+        /// <value>The response to the server authentication challenge.</value>
+        [JsonProperty(PropertyName = "sasl")]
+        public string Sasl { get; set; }
     }
 }

--- a/src/Gremlin.Net/Messages/AuthenticationRequestMessage.cs
+++ b/src/Gremlin.Net/Messages/AuthenticationRequestMessage.cs
@@ -22,22 +22,22 @@ using Newtonsoft.Json;
 namespace Gremlin.Net.Messages
 {
     /// <summary>
-    /// Represents a script request message to send to a Gremlin Server.
+    /// Represents a authentication request message to send to a Gremlin Server.
     /// </summary>
-    public class ScriptRequestMessage : RequestMessage
+    public class AuthenticationRequestMessage : RequestMessage
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ScriptRequestMessage"/> class.
+        /// Initializes a new instance of the <see cref="AuthenticationRequestMessage"/> class.
         /// </summary>
-        public ScriptRequestMessage()
+        public AuthenticationRequestMessage()
         {
-            this.Operation = "eval";
+            this.Operation = "authentication";
         }
 
         /// <summary>
-        /// Gets or sets parameters for this <see cref="ScriptRequestMessage"/> to pass to Gremlin Server.
+        /// Gets or sets parameters for this <see cref="AuthenticationRequestMessage"/> to pass to Gremlin Server.
         /// </summary>
         [JsonProperty(PropertyName = "args")]
-        public ScriptRequestArguments Arguments { get; set; }
+        public AuthenticationRequestArguments Arguments { get; set; }
     }
 }

--- a/src/Gremlin.Net/Messages/RequestMessage.cs
+++ b/src/Gremlin.Net/Messages/RequestMessage.cs
@@ -1,0 +1,50 @@
+﻿#region License
+/*
+ * Copyright 2016 Florian Hockmann
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#endregion
+
+using System;
+using Newtonsoft.Json;
+
+namespace Gremlin.Net.Messages
+{
+    /// <summary>
+    /// Represents a script request message to send to a Gremlin Server.
+    /// </summary>
+    public class RequestMessage
+    {
+        /// <summary>
+        /// Gets the ID of this request message.
+        /// </summary>
+        /// <value>A UUID representing the unique identification for the request.</value>
+        [JsonProperty(PropertyName = "requestId")]
+        public Guid RequestId => Guid.NewGuid();
+
+        /// <summary>
+        /// Gets or sets the name of the operation that should be executed by the Gremlin Server.
+        /// </summary>
+        /// <value>The name of the "operation" to execute based on the available OpProcessor configured in the Gremlin Server.</value>
+        [JsonProperty(PropertyName = "op")]
+        public string Operation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the OpProcessor to utilize.
+        /// </summary>
+        /// <value>The name of the OpProcessor to utilize. This defaults to an empty string which represents the default OpProcessor for evaluating scripts.</value>
+        [JsonProperty(PropertyName = "processor")]
+        public string Processor { get; set; } = "";
+    }
+}

--- a/src/Gremlin.Net/Messages/ResponseStatusCode.cs
+++ b/src/Gremlin.Net/Messages/ResponseStatusCode.cs
@@ -44,9 +44,9 @@ namespace Gremlin.Net.Messages
                 case ResponseStatusCode.Success:
                 case ResponseStatusCode.NoContent:
                 case ResponseStatusCode.PartialContent:
+                case ResponseStatusCode.Authenticate:
                     return false;
                 case ResponseStatusCode.Unauthorized:
-                case ResponseStatusCode.Authenticate:
                 case ResponseStatusCode.MalformedRequest:
                 case ResponseStatusCode.InvalidRequestArguments:
                 case ResponseStatusCode.ServerError:

--- a/test/Gremlin.Net.UnitTest/MessagesTests.cs
+++ b/test/Gremlin.Net.UnitTest/MessagesTests.cs
@@ -31,5 +31,14 @@ namespace Gremlin.Net.UnitTest
 
             Assert.NotEqual(firstMsg.RequestId, secondMsg.RequestId);
         }
+
+        [Theory]
+        [InlineData("username", "password")]
+        public void BuildCorrectSasl(string username, string password)
+        {
+            var argument = new AuthenticationRequestArguments(username, password);
+
+            Assert.Equal($"\0{username}\0{password}", argument.Sasl);
+        }
     }
 }


### PR DESCRIPTION
Added username and password (default values are null) to the constructor of GremlinServer class. Connection.ReceiveAsync() sends out AuthenticationRequestMessage when receiving a response status 407 Authenticate. 

Manually tested using Azure Cosmos DB, it works. Could not write integration tests because the local Gremlin Server has problem on deserializing the SASL message.